### PR TITLE
Changed the linting and format strategies

### DIFF
--- a/.github/workflows/mazy-cicd.yml
+++ b/.github/workflows/mazy-cicd.yml
@@ -1,4 +1,4 @@
-name: Python application
+name: Mazy CICD pipeline
 
 on:
   push:
@@ -28,12 +28,10 @@ jobs:
     - name: Typing check with mypy
       run: |
         poetry run mypy --strict .
-    - name: Linting with flake8
+    - name: Lint and format checks with ruff
       run: |
-        poetry run flake8 .
-    - name: Checking imports with isort
-      run: |
-        poetry run isort ./src ./tests -c -v
+        poetry run ruff check .
+        poetry run ruff format . --check
     - name: Test with pytest
       run: |
         poetry run pytest

--- a/poetry.lock
+++ b/poetry.lock
@@ -39,46 +39,6 @@ tests = ["attrs[tests-no-zope]", "zope-interface"]
 tests-no-zope = ["cloudpickle", "hypothesis", "mypy (>=1.1.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 
 [[package]]
-name = "black"
-version = "23.10.1"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "black-23.10.1-cp310-cp310-macosx_10_16_arm64.whl", hash = "sha256:ec3f8e6234c4e46ff9e16d9ae96f4ef69fa328bb4ad08198c8cee45bb1f08c69"},
-    {file = "black-23.10.1-cp310-cp310-macosx_10_16_x86_64.whl", hash = "sha256:1b917a2aa020ca600483a7b340c165970b26e9029067f019e3755b56e8dd5916"},
-    {file = "black-23.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9c74de4c77b849e6359c6f01987e94873c707098322b91490d24296f66d067dc"},
-    {file = "black-23.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:7b4d10b0f016616a0d93d24a448100adf1699712fb7a4efd0e2c32bbb219b173"},
-    {file = "black-23.10.1-cp311-cp311-macosx_10_16_arm64.whl", hash = "sha256:b15b75fc53a2fbcac8a87d3e20f69874d161beef13954747e053bca7a1ce53a0"},
-    {file = "black-23.10.1-cp311-cp311-macosx_10_16_x86_64.whl", hash = "sha256:e293e4c2f4a992b980032bbd62df07c1bcff82d6964d6c9496f2cd726e246ace"},
-    {file = "black-23.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d56124b7a61d092cb52cce34182a5280e160e6aff3137172a68c2c2c4b76bcb"},
-    {file = "black-23.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:3f157a8945a7b2d424da3335f7ace89c14a3b0625e6593d21139c2d8214d55ce"},
-    {file = "black-23.10.1-cp38-cp38-macosx_10_16_arm64.whl", hash = "sha256:cfcce6f0a384d0da692119f2d72d79ed07c7159879d0bb1bb32d2e443382bf3a"},
-    {file = "black-23.10.1-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:33d40f5b06be80c1bbce17b173cda17994fbad096ce60eb22054da021bf933d1"},
-    {file = "black-23.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:840015166dbdfbc47992871325799fd2dc0dcf9395e401ada6d88fe11498abad"},
-    {file = "black-23.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:037e9b4664cafda5f025a1728c50a9e9aedb99a759c89f760bd83730e76ba884"},
-    {file = "black-23.10.1-cp39-cp39-macosx_10_16_arm64.whl", hash = "sha256:7cb5936e686e782fddb1c73f8aa6f459e1ad38a6a7b0e54b403f1f05a1507ee9"},
-    {file = "black-23.10.1-cp39-cp39-macosx_10_16_x86_64.whl", hash = "sha256:7670242e90dc129c539e9ca17665e39a146a761e681805c54fbd86015c7c84f7"},
-    {file = "black-23.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ed45ac9a613fb52dad3b61c8dea2ec9510bf3108d4db88422bacc7d1ba1243d"},
-    {file = "black-23.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:6d23d7822140e3fef190734216cefb262521789367fbdc0b3f22af6744058982"},
-    {file = "black-23.10.1-py3-none-any.whl", hash = "sha256:d431e6739f727bb2e0495df64a6c7a5310758e87505f5f8cde9ff6c0f2d7e4fe"},
-    {file = "black-23.10.1.tar.gz", hash = "sha256:1f8ce316753428ff68749c65a5f7844631aa18c8679dfd3ca9dc1a289979c258"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "cffi"
 version = "1.16.0"
 description = "Foreign Function Interface for Python calling C code."
@@ -143,20 +103,6 @@ files = [
 pycparser = "*"
 
 [[package]]
-name = "click"
-version = "8.1.7"
-description = "Composable command line interface toolkit"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
-    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
-]
-
-[package.dependencies]
-colorama = {version = "*", markers = "platform_system == \"Windows\""}
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -182,22 +128,6 @@ files = [
 python-dateutil = ">=2.4"
 
 [[package]]
-name = "flake8"
-version = "6.1.0"
-description = "the modular source code checker: pep8 pyflakes and co"
-optional = false
-python-versions = ">=3.8.1"
-files = [
-    {file = "flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"},
-    {file = "flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23"},
-]
-
-[package.dependencies]
-mccabe = ">=0.7.0,<0.8.0"
-pycodestyle = ">=2.11.0,<2.12.0"
-pyflakes = ">=3.1.0,<3.2.0"
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -206,34 +136,6 @@ python-versions = ">=3.7"
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
-]
-
-[[package]]
-name = "isort"
-version = "5.12.0"
-description = "A Python utility / library to sort Python imports."
-optional = false
-python-versions = ">=3.8.0"
-files = [
-    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
-    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
-]
-
-[package.extras]
-colors = ["colorama (>=0.4.3)"]
-pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
-plugins = ["setuptools"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
-
-[[package]]
-name = "mccabe"
-version = "0.7.0"
-description = "McCabe checker, plugin for flake8"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 
 [[package]]
@@ -301,17 +203,6 @@ python-versions = ">=3.7"
 files = [
     {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
     {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
-]
-
-[[package]]
-name = "pathspec"
-version = "0.11.2"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pathspec-0.11.2-py3-none-any.whl", hash = "sha256:1d6ed233af05e679efb96b1851550ea95bbb64b7c490b0f5aa52996c11e92a20"},
-    {file = "pathspec-0.11.2.tar.gz", hash = "sha256:e0d8d0ac2f12da61956eb2306b69f9469b42f4deb0f3cb6ed47b9cce9996ced3"},
 ]
 
 [[package]]
@@ -389,21 +280,6 @@ docs = ["furo", "olefile", "sphinx (>=2.4)", "sphinx-copybutton", "sphinx-issues
 tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
 
 [[package]]
-name = "platformdirs"
-version = "3.11.0"
-description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "platformdirs-3.11.0-py3-none-any.whl", hash = "sha256:e9d171d00af68be50e9202731309c4e658fd8bc76f55c11c7dd760d023bda68e"},
-    {file = "platformdirs-3.11.0.tar.gz", hash = "sha256:cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"},
-]
-
-[package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
-
-[[package]]
 name = "pluggy"
 version = "1.3.0"
 description = "plugin and hook calling mechanisms for python"
@@ -419,17 +295,6 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
-name = "pycodestyle"
-version = "2.11.1"
-description = "Python style guide checker"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pycodestyle-2.11.1-py2.py3-none-any.whl", hash = "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"},
-    {file = "pycodestyle-2.11.1.tar.gz", hash = "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f"},
-]
-
-[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -438,17 +303,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
-]
-
-[[package]]
-name = "pyflakes"
-version = "3.1.0"
-description = "passive checker of Python programs"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
-    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
 ]
 
 [[package]]
@@ -584,6 +438,32 @@ tests = ["black", "flake8", "isort (>=4.2.5,<5)", "mypy", "pytest", "pytest-cov"
 zstd = ["zstd (==1.4.8.1)"]
 
 [[package]]
+name = "ruff"
+version = "0.1.6"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.1.6-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:88b8cdf6abf98130991cbc9f6438f35f6e8d41a02622cc5ee130a02a0ed28703"},
+    {file = "ruff-0.1.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5c549ed437680b6105a1299d2cd30e4964211606eeb48a0ff7a93ef70b902248"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cf5f701062e294f2167e66d11b092bba7af6a057668ed618a9253e1e90cfd76"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:05991ee20d4ac4bb78385360c684e4b417edd971030ab12a4fbd075ff535050e"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87455a0c1f739b3c069e2f4c43b66479a54dea0276dd5d4d67b091265f6fd1dc"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:683aa5bdda5a48cb8266fcde8eea2a6af4e5700a392c56ea5fb5f0d4bfdc0240"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:137852105586dcbf80c1717facb6781555c4e99f520c9c827bd414fac67ddfb6"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd98138a98d48a1c36c394fd6b84cd943ac92a08278aa8ac8c0fdefcf7138f35"},
+    {file = "ruff-0.1.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a0cd909d25f227ac5c36d4e7e681577275fb74ba3b11d288aff7ec47e3ae745"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8fd1c62a47aa88a02707b5dd20c5ff20d035d634aa74826b42a1da77861b5ff"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fd89b45d374935829134a082617954120d7a1470a9f0ec0e7f3ead983edc48cc"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:491262006e92f825b145cd1e52948073c56560243b55fb3b4ecb142f6f0e9543"},
+    {file = "ruff-0.1.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ea284789861b8b5ca9d5443591a92a397ac183d4351882ab52f6296b4fdd5462"},
+    {file = "ruff-0.1.6-py3-none-win32.whl", hash = "sha256:1610e14750826dfc207ccbcdd7331b6bd285607d4181df9c1c6ae26646d6848a"},
+    {file = "ruff-0.1.6-py3-none-win_amd64.whl", hash = "sha256:4558b3e178145491e9bc3b2ee3c4b42f19d19384eaa5c59d10acf6e8f8b57e33"},
+    {file = "ruff-0.1.6-py3-none-win_arm64.whl", hash = "sha256:03910e81df0d8db0e30050725a5802441c2022ea3ae4fe0609b76081731accbc"},
+    {file = "ruff-0.1.6.tar.gz", hash = "sha256:1b09f29b16c6ead5ea6b097ef2764b42372aebe363722f1605ecbcd2b9207184"},
+]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -608,4 +488,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "4ca272113ef9886ba14e40162621fb65c99721295f361e6d90077901c870d4d5"
+content-hash = "652031daed6f9b694206bed993fe9b6c2c36f31d1d7f3089630d82e7f50ad681"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,13 @@ arcade = "^2.6.17"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
-black = "^23.10.1"
 mypy = "^1.6.1"
 faker = "^19.13.0"
-flake8 = "^6.1.0"
-isort = "^5.12.0"
+ruff = "^0.1.6"
+
+[tool.ruff]
+select = ["D100", "D101", "D102", "D103", "D201", "D202", "D204", "D205", "D211", "D400"]
+
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/mazy/builders/base_builder.py
+++ b/src/mazy/builders/base_builder.py
@@ -1,8 +1,16 @@
+"""Contract for maze builders."""
 from typing import Generator, Protocol
 
 from mazy.models.maze import Maze
 
 
 class MazeBuilder(Protocol):
+    """Contract for maze builders."""
+
     def build_maze(self, rows: int, cols: int) -> Generator[Maze, None, None]:
+        """Build a maze.
+
+        Returns a Maze generator. This is useful to get each state of the
+        maze during the building process.
+        """
         ...

--- a/src/mazy/builders/binary_tree_builder.py
+++ b/src/mazy/builders/binary_tree_builder.py
@@ -1,3 +1,4 @@
+"""Binary Tree Maze builder."""
 import random
 from typing import Generator
 
@@ -8,8 +9,11 @@ NAVIGATION_DIRECTIONS = [Direction.EAST, Direction.SOUTH]
 
 
 class BinaryTreeBuilder:
+    """Binary Tree Maze builder."""
+
     @staticmethod
     def build_maze(rows: int, cols: int) -> Generator[Maze, None, None]:
+        """Build a maze using Binary Tree algorithm."""
         maze = Maze(rows, cols)
 
         for cell in maze.traverse_by_cell():

--- a/src/mazy/exceptions.py
+++ b/src/mazy/exceptions.py
@@ -1,3 +1,6 @@
+"""Exceptions."""
+
+
 class NeighborhoodError(Exception):
     """Consistence error between cells and directions."""
 

--- a/src/mazy/models/cell.py
+++ b/src/mazy/models/cell.py
@@ -1,3 +1,4 @@
+"""Definitions related to a cell."""
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum, auto
 
@@ -5,6 +6,8 @@ from mazy.exceptions import DuplicatedNeighbor, MissingLink, NeighborhoodError
 
 
 class Role(IntEnum):
+    """Possible roles for a cell."""
+
     NONE = 0
     ENTRANCE = auto()
     EXIT = auto()
@@ -13,12 +16,15 @@ class Role(IntEnum):
 
 
 class Direction(Enum):
+    """Directions relative to the current cell."""
+
     NORTH = "north"
     SOUTH = "south"
     EAST = "east"
     WEST = "west"
 
     def opposite(self) -> "Direction":
+        """The opposite direction relative to the current one."""
         direction: Direction
         match self:
             case self.NORTH:
@@ -35,12 +41,20 @@ class Direction(Enum):
 
 @dataclass
 class Neighbor:
+    """Cell linked to another cell in one direction.
+
+    When a cell is next to the other in one direction, it is
+    stored as a neighbor. A neigh can have or not a passage.
+    """
+
     cell: "Cell"
     passage: bool
 
 
 @dataclass
 class Cell:
+    """Basic building block of a maze."""
+
     row: int
     col: int
 
@@ -48,6 +62,7 @@ class Cell:
     neighbors: dict[Direction, Neighbor] = field(default_factory=dict)
 
     def __repr__(self) -> str:
+        """Text representation of a Cell object."""
         return f"Cell(row: {self.row}, col: {self.col})"
 
     def link_to(
@@ -57,6 +72,7 @@ class Cell:
         direction: Direction,
         bidirectional: bool = True,
     ) -> None:
+        """Link one cell to another creating a neighbor."""
         if not is_neighborhood_valid(
             cell=self, neighbor=other_cell, direction=direction
         ):
@@ -79,6 +95,7 @@ class Cell:
     def unlink_from(
         self, other_cell: "Cell", direction: Direction, bidirectional: bool = True
     ) -> None:
+        """Unlink one cell from the other removing a neighbor."""
         if not is_neighborhood_valid(
             cell=self, neighbor=other_cell, direction=direction
         ):

--- a/src/mazy/models/maze.py
+++ b/src/mazy/models/maze.py
@@ -1,3 +1,4 @@
+"""Definitions related to a maze."""
 from enum import Enum
 from typing import Generator, Sequence
 
@@ -5,11 +6,15 @@ from mazy.models.cell import Cell, Direction, Role
 
 
 class MazeState(Enum):
+    """Possible states of a maze."""
+
     BUILDING = "building"
     READY = "ready"
 
 
 class Maze:
+    """Maze as a grid of cells."""
+
     def __init__(self, rows: int, cols: int):
         self.state = MazeState.BUILDING
         self.rows = rows
@@ -24,6 +29,11 @@ class Maze:
         return self.cells[i][j]
 
     def registry_neighbors(self) -> None:
+        """Registry all neighbors.
+
+        The external cell have no neighbors at the maze frontiers.
+        The maze have no passages at this moment.
+        """
         self[0, 0].role = Role.ENTRANCE
         self[self.rows - 1, self.cols - 1].role = Role.EXIT
 
@@ -42,6 +52,7 @@ class Maze:
                     )
 
     def traverse_by_cell(self) -> Generator[Cell, None, None]:
+        """Traverse the maze cell by cell."""
         for row in range(self.rows):
             for col in range(self.cols):
                 yield self[row, col]

--- a/src/mazy/utils.py
+++ b/src/mazy/utils.py
@@ -1,3 +1,4 @@
+"""Utility functions for general use."""
 from typing import Generator, TypeVar
 
 T = TypeVar("T")

--- a/src/mazy/viewers/ascii_viewer.py
+++ b/src/mazy/viewers/ascii_viewer.py
@@ -1,13 +1,17 @@
+"""Text viewer."""
 from mazy.models.cell import Direction, Role
 from mazy.models.maze import Maze
 from mazy.viewers.base_viewer import MazeViewer
 
 
 class MazeTextViewer(MazeViewer):
+    """Text viewer."""
+
     def __init__(self, maze: Maze) -> None:
         self.maze = maze
 
     def show_maze(self) -> None:
+        """Print a text representation of the maze."""
         print(self.maze_to_str())
 
     def maze_to_str(self) -> str:

--- a/src/mazy/viewers/base_viewer.py
+++ b/src/mazy/viewers/base_viewer.py
@@ -1,3 +1,4 @@
+"""Contract for maze viewers."""
 from abc import abstractmethod
 from typing import Protocol
 
@@ -5,8 +6,11 @@ from mazy.models.maze import Maze
 
 
 class MazeViewer(Protocol):
+    """Contract for maze viewers."""
+
     maze: Maze
 
     @abstractmethod
     def show_maze(self) -> None:
+        """Show the maze."""
         ...

--- a/src/mazy/viewers/graphical_viewer.py
+++ b/src/mazy/viewers/graphical_viewer.py
@@ -1,3 +1,4 @@
+"""Graphical viewer."""
 from dataclasses import dataclass
 from typing import Generator
 
@@ -17,6 +18,12 @@ EXTERNAL_SIZE = 32
 
 @dataclass
 class Wall:
+    """Primitive coordinates of a wall.
+
+    In fact, a wall is a line representing the border
+    of a cell.
+    """
+
     x1: int
     y1: int
     x2: int
@@ -24,10 +31,13 @@ class Wall:
 
 
 class MazeGraphicalViewer(MazeViewer):
+    """Graphical viewer."""
+
     def __init__(self, maze: Maze) -> None:
         self.maze = maze
 
     def show_maze(self) -> None:
+        """Render and show the graphical representation of the maze."""
         processor = MazeGraphicalProcessor(self.maze)
         gui = MazeGraphicalRenderer(
             rows=self.maze.rows, cols=self.maze.cols, processor=processor
@@ -36,6 +46,8 @@ class MazeGraphicalViewer(MazeViewer):
 
 
 class MazeGraphicalProcessor:
+    """Process graphical information of the maze."""
+
     def __init__(self, maze: Maze):
         self.maze = maze
 
@@ -45,6 +57,7 @@ class MazeGraphicalProcessor:
         return self.maze.rows * CELL_SIZE + EXTERNAL_SIZE - 1
 
     def process_walls(self, cell: Cell) -> list[Wall]:
+        """Calculate primitive coordinates of the maze walls."""
         x1 = EXTERNAL_SIZE + cell.col * CELL_SIZE
         y1 = self.delta_y - cell.row * CELL_SIZE
 
@@ -86,12 +99,19 @@ class MazeGraphicalProcessor:
         return walls
 
     def process_maze(self) -> Generator[Wall, None, None]:
+        """Traverse the maze processing graphical information cell by cell."""
         for cell in self.maze.traverse_by_cell():
             for wall in self.process_walls(cell):
                 yield wall
 
 
 class MazeGraphicalRenderer(Window):
+    """Arcade graphical renderer.
+
+    Extends Arcade Window object, drawing a window with
+    a canvas for the maze graphical representation.
+    """
+
     def __init__(self, rows: int, cols: int, processor: MazeGraphicalProcessor):
         self.processor = processor
 
@@ -103,6 +123,7 @@ class MazeGraphicalRenderer(Window):
         set_background_color(BACKGROUND_COLOR)
 
     def on_draw(self) -> None:
+        """Render all objects for the active window."""
         self.clear()
 
         for wall in self.processor.process_maze():

--- a/tests/builders/test_binary_tree_builder.py
+++ b/tests/builders/test_binary_tree_builder.py
@@ -1,3 +1,4 @@
+"""Tests for the binary tree builder."""
 from mazy.builders.binary_tree_builder import BinaryTreeBuilder
 from mazy.utils import consume_generator
 

--- a/tests/models/test_cell.py
+++ b/tests/models/test_cell.py
@@ -1,3 +1,4 @@
+"""Tests for the cell model."""
 from typing import Optional
 
 import pytest
@@ -25,6 +26,7 @@ def test_cell_opposite_direction(
     direction: Direction,
     expected_opposite: Direction,
 ) -> None:
+    """Should return the opposite of a given direction."""
     assert direction.opposite() == expected_opposite
 
 

--- a/tests/models/test_maze.py
+++ b/tests/models/test_maze.py
@@ -1,3 +1,4 @@
+"""Tests for the maze model."""
 from mazy.models.cell import Cell, Direction, Role
 from mazy.models.maze import Maze, MazeState
 

--- a/tests/test_maze_maker.py
+++ b/tests/test_maze_maker.py
@@ -1,12 +1,18 @@
+"""Tests for the command line CLI."""
 from unittest.mock import Mock, patch
 
 import pytest
 from _pytest.capture import CaptureFixture
 from faker import Faker
 
-from mazy.maze_maker import (DEFAULT_MAZE_BUILDER, DEFAULT_MAZE_VIEWER,
-                             DEFAULT_NUMBER_OF_COLS, DEFAULT_NUMBER_OF_ROWS,
-                             make_maze, validate_args)
+from mazy.maze_maker import (
+    DEFAULT_MAZE_BUILDER,
+    DEFAULT_MAZE_VIEWER,
+    DEFAULT_NUMBER_OF_COLS,
+    DEFAULT_NUMBER_OF_ROWS,
+    make_maze,
+    validate_args,
+)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,12 @@
+"""Tests for the utility functions."""
 from typing import Generator
 
 from mazy.utils import consume_generator
 
 
 def test_utils_consume_generator() -> None:
+    """Should consume a generator and return the final result."""
+
     def numbers(limit: int) -> Generator[int, None, None]:
         for i in range(limit + 1):
             yield i

--- a/tests/viewers/test_ascii_viewer.py
+++ b/tests/viewers/test_ascii_viewer.py
@@ -1,3 +1,4 @@
+"""Tests for the text (ASCII) viewer."""
 import pytest
 
 from mazy.builders.binary_tree_builder import BinaryTreeBuilder

--- a/tests/viewers/test_graphical_viewer.py
+++ b/tests/viewers/test_graphical_viewer.py
@@ -1,9 +1,14 @@
+"""Tests for the graphical viewer."""
 from unittest.mock import Mock, patch
 
 from mazy.models.maze import Maze
-from mazy.viewers.graphical_viewer import (CELL_SIZE, EXTERNAL_SIZE,
-                                           MazeGraphicalProcessor,
-                                           MazeGraphicalViewer, Wall)
+from mazy.viewers.graphical_viewer import (
+    CELL_SIZE,
+    EXTERNAL_SIZE,
+    MazeGraphicalProcessor,
+    MazeGraphicalViewer,
+    Wall,
+)
 
 
 @patch("mazy.viewers.graphical_viewer.MazeGraphicalRenderer")
@@ -17,6 +22,11 @@ def test_graphical_viewer_calls_graphical_renderer(
 
 
 def test_graphical_processor_process_entrance_and_exit() -> None:
+    """Should not draw a border neither for the ENTRANCE nor for the EXIT.
+
+    The entrance can not have a border on the NORTH.
+    The EXIT can not have a border on the SOUTH.
+    """
     maze = Maze(2, 2)
     processor = MazeGraphicalProcessor(maze)
     walls = processor.process_walls(maze[0, 0])
@@ -45,6 +55,7 @@ def test_graphical_processor_process_entrance_and_exit() -> None:
 
 
 def test_graphical_processor_process_external_walls() -> None:
+    """Must draw all the external walls except for the entrance and the exit."""
     maze = Maze(2, 3)
     processor = MazeGraphicalProcessor(maze)
 


### PR DESCRIPTION
Replaced flake8 and isort by ruff.
Fixed all linting issues previously ignored.
Replaced Black by Ruff formatter.
Fixed format divergences with Black.
Updated the CICD pipeline.
Removed Black, isort and flake8 dependencies.