### PR TITLE
Basic structures to support Dijkstra's Shortest Path solver

### DIFF
--- a/src/mazy/models/cell.py
+++ b/src/mazy/models/cell.py
@@ -1,6 +1,7 @@
 """Models related to a cell."""
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum, auto
+from typing import Optional
 
 from mazy.exceptions import DuplicatedNeighbor, MissingLink, NeighborhoodError
 
@@ -58,6 +59,9 @@ class Cell:
 
     role: Role = Role.NONE
     visited: bool = False
+    solution: bool = False
+    content: Optional[str] = None
+
     neighbors: dict[Direction, Neighbor] = field(default_factory=dict)
 
     def __repr__(self) -> str:

--- a/src/mazy/models/cell.py
+++ b/src/mazy/models/cell.py
@@ -2,6 +2,7 @@
 from dataclasses import dataclass, field
 from enum import Enum, IntEnum, auto
 from typing import Optional
+from uuid import UUID, uuid4
 
 from mazy.exceptions import DuplicatedNeighbor, MissingLink, NeighborhoodError
 
@@ -61,8 +62,23 @@ class Cell:
     visited: bool = False
     solution: bool = False
     content: Optional[str] = None
-
     neighbors: dict[Direction, Neighbor] = field(default_factory=dict)
+
+    _id: UUID = field(init=False, default_factory=uuid4)
+
+    @property
+    def id(self) -> UUID:
+        """Immutable-like identification for a cell."""
+        return self._id
+
+    def __hash__(self) -> int:
+        """Make the cell object hashable.
+
+        Cells are mutable objects, but they need an immutable independent field
+        to make possible to use cells in hashmaps even if the values of the cell
+        attributes change along the time.
+        """
+        return hash(self._id)
 
     def __repr__(self) -> str:
         """Text representation of a Cell object."""

--- a/src/mazy/models/cell.py
+++ b/src/mazy/models/cell.py
@@ -186,6 +186,12 @@ class Cell:
             ]
         )
 
+    def passages(self) -> list["Cell"]:
+        """Return the list of neighbor cells with a carved passage."""
+        return [
+            neighbor.cell for neighbor in self.neighbors.values() if neighbor.passage
+        ]
+
 
 def is_neighborhood_valid(cell: Cell, neighbor: Cell, direction: Direction) -> bool:
     """Validate the neighborhood between 2 cells in a given direction.

--- a/src/mazy/models/solver.py
+++ b/src/mazy/models/solver.py
@@ -1,0 +1,22 @@
+"""Models related to maze solvers."""
+from dataclasses import dataclass, field
+from enum import Enum
+
+from mazy.models.cell import Cell
+
+
+class SolverAlgorithm(Enum):
+    """Maze solver algorithms domain."""
+
+    DIJKSTRA_SHORTEST_PATH = "dijkstra-shortest-path"
+
+
+@dataclass
+class Distances:
+    """Distance matrix to support distance-based solvers."""
+
+    root: Cell
+    cells: dict[Cell, int] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.cells[self.root] = 0

--- a/src/mazy/models/solver.py
+++ b/src/mazy/models/solver.py
@@ -16,7 +16,28 @@ class Distances:
     """Distance matrix to support distance-based solvers."""
 
     root: Cell
-    cells: dict[Cell, int] = field(default_factory=dict)
+    cells: dict[Cell, int] = field(init=False, default_factory=dict)
 
     def __post_init__(self) -> None:
         self.cells[self.root] = 0
+
+    def __getitem__(self, key: Cell) -> int:
+        if not isinstance(key, Cell):
+            raise ValueError(
+                "Only a Cell object can be used as key for the distance matrix!"
+            )
+
+        return self.cells[key]
+
+    def __setitem__(self, key: Cell, value: int) -> None:
+        if not isinstance(key, Cell):
+            raise ValueError(
+                "Only a Cell object can be used as key for the distance matrix!"
+            )
+
+        if not isinstance(value, int):
+            raise ValueError(
+                "Only an integer number can be used as value for the distance matrix!"
+            )
+
+        self.cells[key] = value

--- a/src/mazy/solvers/base_solver.py
+++ b/src/mazy/solvers/base_solver.py
@@ -1,0 +1,17 @@
+"""Contract for maze solvers."""
+from abc import ABC, abstractmethod
+
+from mazy.models.maze import Maze
+
+
+class MazeSolver(ABC):
+    """Abstraction for maze solvers."""
+
+    def __init__(self, maze: Maze):
+        self.maze = maze
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Solver name."""
+        ...

--- a/src/mazy/solvers/dijkstra_shortest_path.py
+++ b/src/mazy/solvers/dijkstra_shortest_path.py
@@ -1,0 +1,11 @@
+"""Dijkstra's Shortest Path maze solver."""
+from mazy.solvers.base_solver import MazeSolver
+
+
+class DijkstraShortestPathSolver(MazeSolver):
+    """Dijkstra's Shortest Path maze solver."""
+
+    @property
+    def name(self) -> str:
+        """Solver name."""
+        return "dijkstra-shortest-path"

--- a/src/mazy/solvers/dijkstra_shortest_path.py
+++ b/src/mazy/solvers/dijkstra_shortest_path.py
@@ -1,4 +1,8 @@
 """Dijkstra's Shortest Path maze solver."""
+from typing import Optional
+
+from mazy.models.cell import Cell
+from mazy.models.solver import Distances
 from mazy.solvers.base_solver import MazeSolver
 
 
@@ -9,3 +13,26 @@ class DijkstraShortestPathSolver(MazeSolver):
     def name(self) -> str:
         """Solver name."""
         return "dijkstra-shortest-path"
+
+    def calculate_distances(self) -> Distances:
+        """Given a maze, calculate the distance from the root cell to all the others.
+
+        The calculation is made only for neighbor cells with a carved passage.
+        """
+        root = self.maze[0, 0]
+        distances = Distances(root)
+
+        frontier: list[tuple[Optional[Cell], Cell]] = [(None, root)]
+
+        while len(frontier) > 0:
+            new_frontier: list[tuple[Optional[Cell], Cell]] = []
+
+            for previous_cell, current_cell in frontier:
+                for neighbor_cell in current_cell.passages():
+                    if neighbor_cell is not previous_cell:
+                        distances[neighbor_cell] = distances[current_cell] + 1
+                        new_frontier.append((current_cell, neighbor_cell))
+
+            frontier = new_frontier
+
+        return distances

--- a/src/mazy/viewers/ascii_viewer.py
+++ b/src/mazy/viewers/ascii_viewer.py
@@ -35,10 +35,11 @@ class MazeTextViewer(MazeViewer):
 
             for col in range(maze.cols):
                 cell = maze[row, col]
+                content = cell.content.center(4) if cell.content else "    "
                 maze_str += (
-                    "     "
+                    f" {content}"
                     if cell.has_passage_to_direction(Direction.WEST)
-                    else "|    "
+                    else f"|{content}"
                 )
                 if col == maze.cols - 1:
                     maze_str += "|"

--- a/tests/builders/test_binary_tree_builder.py
+++ b/tests/builders/test_binary_tree_builder.py
@@ -40,3 +40,13 @@ def test_binary_tree_builder_build_maze_manages_maze_states() -> None:
 
     assert next(maze_generator).state == MazeState.BUILDING
     assert consume_generator(maze_generator).state == MazeState.READY
+
+
+def test_binary_tree_builder_build_maze_does_not_change_cell_solution_fields() -> None:
+    """Should not change cell fields related to the maze solution path."""
+    builder = BinaryTreeBuilder(rows=3, cols=5)
+    maze = consume_generator(builder.build_maze())
+
+    for cell in maze.traverse_by_cell():
+        assert cell.solution is False
+        assert cell.content is None

--- a/tests/builders/test_dummy_builder.py
+++ b/tests/builders/test_dummy_builder.py
@@ -40,3 +40,13 @@ def test_dummy_builder_build_maze_manages_maze_states() -> None:
 
     assert next(maze_generator).state == MazeState.BUILDING
     assert consume_generator(maze_generator).state == MazeState.READY
+
+
+def test_dummy_builder_build_maze_does_not_change_cell_solution_fields() -> None:
+    """Should not change cell fields related to the maze solution path."""
+    builder = DummyBuilder(rows=3, cols=5)
+    maze = consume_generator(builder.build_maze())
+
+    for cell in maze.traverse_by_cell():
+        assert cell.solution is False
+        assert cell.content is None

--- a/tests/builders/test_sidewinder_builder.py
+++ b/tests/builders/test_sidewinder_builder.py
@@ -41,3 +41,13 @@ def test_sidewinder_builder_build_maze_manages_maze_states() -> None:
 
     assert next(maze_generator).state == MazeState.BUILDING
     assert consume_generator(maze_generator).state == MazeState.READY
+
+
+def test_sidewinder_builder_build_maze_does_not_change_cell_solution_fields() -> None:
+    """Should not change cell fields related to the maze solution path."""
+    builder = SidewinderBuilder(rows=3, cols=5)
+    maze = consume_generator(builder.build_maze())
+
+    for cell in maze.traverse_by_cell():
+        assert cell.solution is False
+        assert cell.content is None

--- a/tests/models/test_cell.py
+++ b/tests/models/test_cell.py
@@ -12,6 +12,8 @@ def test_cell_default_values() -> None:
     cell = Cell(row=0, col=1)
     assert cell.role == Role.NONE
     assert cell.visited is False
+    assert cell.solution is False
+    assert cell.content is None
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_cell.py
+++ b/tests/models/test_cell.py
@@ -300,3 +300,20 @@ def test_cell_passage_count() -> None:
     cell.link_to(cell_on_south, passage=True, direction=Direction.SOUTH)
 
     assert cell.passage_count() == 2
+
+
+def test_cell_neighbors_with_carved_passage() -> None:
+    """Should return the collection of neighbors cells with a carved passage."""
+    cell = Cell(row=1, col=1)
+
+    cell_on_east = Cell(row=1, col=2)
+    cell.link_to(cell_on_east, passage=True, direction=Direction.EAST)
+    cell_on_south = Cell(row=2, col=1)
+    cell.link_to(cell_on_south, passage=True, direction=Direction.SOUTH)
+
+    cell_on_west = Cell(row=1, col=0)  # Has no passage
+    cell.link_to(cell_on_west, passage=False, direction=Direction.WEST)
+
+    expected_cells = [cell_on_east, cell_on_south]
+
+    assert cell.passages() == expected_cells

--- a/tests/models/test_cell.py
+++ b/tests/models/test_cell.py
@@ -16,6 +16,24 @@ def test_cell_default_values() -> None:
     assert cell.content is None
 
 
+def test_cell_is_hashable() -> None:
+    """Ensure that objects of the Cell class are hashable."""
+    cell = Cell(0, 0)
+    assert hash(cell) == hash(cell.id)
+
+
+def test_cell_identity_and_equality() -> None:
+    """Should properly compare two instances of the Cell class."""
+    cell = Cell(0, 0)
+    same_cell = cell
+    other_cell = Cell(0, 0)
+
+    assert cell is same_cell
+    assert cell == same_cell
+    assert cell is not other_cell
+    assert cell != other_cell
+
+
 @pytest.mark.parametrize(
     ("direction", "expected_opposite"),
     [

--- a/tests/models/test_solver.py
+++ b/tests/models/test_solver.py
@@ -1,0 +1,9 @@
+"""Tests for the solver model."""
+from mazy.models.cell import Cell
+from mazy.models.solver import Distances
+
+
+def test_solver_distance_root_cell_default() -> None:
+    """Should initialize the distance matrix with a root cell with default value."""
+    distances = Distances(Cell(0, 0))
+    assert distances.cells[distances.root] == 0

--- a/tests/models/test_solver.py
+++ b/tests/models/test_solver.py
@@ -1,9 +1,62 @@
 """Tests for the solver model."""
+import pytest
+
 from mazy.models.cell import Cell
 from mazy.models.solver import Distances
 
 
 def test_solver_distance_root_cell_default() -> None:
     """Should initialize the distance matrix with a root cell with default value."""
-    distances = Distances(Cell(0, 0))
+    distances = Distances(root=Cell(0, 0))
     assert distances.cells[distances.root] == 0
+
+
+def test_solver_distances_get_item() -> None:
+    """Ensure values from the distance matrix can be queried by [] accessor."""
+    cell = Cell(0, 0)
+    distances = Distances(root=cell)
+    assert distances[cell] == 0
+
+
+def test_solver_distances_get_item_raises_when_key_is_not_cell() -> None:
+    """Should raise an error if the key is not a Cell object."""
+    cell = Cell(0, 0)
+    distances = Distances(root=cell)
+
+    with pytest.raises(
+        ValueError,
+        match="Only a Cell object can be used as key for the distance matrix!",
+    ):
+        _ = distances["invalid key"]  # type: ignore[index]
+
+
+def test_solver_distances_set_item() -> None:
+    """Ensure values from the distance matrix can be updated by [] accessor."""
+    distances = Distances(root=Cell(0, 0))
+    new_cell = Cell(0, 1)
+    distances[new_cell] = 1
+    assert distances[new_cell] == 1
+
+
+def test_solver_distances_set_item_raises_when_key_is_not_cell() -> None:
+    """Should raise an error if the key is not a Cell object."""
+    cell = Cell(0, 0)
+    distances = Distances(root=cell)
+
+    with pytest.raises(
+        ValueError,
+        match="Only a Cell object can be used as key for the distance matrix!",
+    ):
+        distances["invalid key"] = 1  # type: ignore[index]
+
+
+def test_solver_distances_set_item_raises_when_value_is_not_int() -> None:
+    """Should raise an error if the value is not an integer."""
+    cell = Cell(0, 0)
+    distances = Distances(root=cell)
+
+    with pytest.raises(
+        ValueError,
+        match="Only an integer number can be used as value for the distance matrix!",
+    ):
+        distances[cell] = "invalid value"  # type: ignore[assignment]

--- a/tests/solvers/test_dijkstra_shortest_path.py
+++ b/tests/solvers/test_dijkstra_shortest_path.py
@@ -1,5 +1,7 @@
 """Tests for the Dijkstra's Shortest Path solver."""
 from mazy.builders.dummy_builder import DummyBuilder
+from mazy.models.cell import Direction
+from mazy.models.maze import Maze
 from mazy.models.solver import SolverAlgorithm
 from mazy.solvers.dijkstra_shortest_path import DijkstraShortestPathSolver
 from mazy.utils import consume_generator
@@ -12,3 +14,35 @@ def test_dijkstra_shortest_path_default_values() -> None:
     solver = DijkstraShortestPathSolver(maze)
 
     assert solver.name == SolverAlgorithm.DIJKSTRA_SHORTEST_PATH.value
+
+
+def test_dijkstra_shortest_path_calculate_distances() -> None:
+    """Should calculate the distance from the root cell for all the other cells."""
+    maze = Maze(2, 3)
+
+    root = maze[0, 0]
+    root.carve_passage_to_direction(Direction.SOUTH)
+
+    south_west_corner_cell = maze[1, 0]
+    south_west_corner_cell.carve_passage_to_direction(Direction.EAST)
+
+    south_central_cell = maze[1, 1]
+    south_central_cell.carve_passage_to_direction(Direction.EAST)
+
+    south_east_corner_cell = maze[1, 2]
+    south_east_corner_cell.carve_passage_to_direction(Direction.NORTH)
+
+    north_east_corner_cell = maze[0, 2]
+    north_east_corner_cell.carve_passage_to_direction(Direction.WEST)
+
+    north_central_cell = maze[0, 1]
+
+    solver = DijkstraShortestPathSolver(maze)
+    distances = solver.calculate_distances()
+
+    assert distances[root] == 0
+    assert distances[south_west_corner_cell] == 1
+    assert distances[south_central_cell] == 2
+    assert distances[south_east_corner_cell] == 3
+    assert distances[north_east_corner_cell] == 4
+    assert distances[north_central_cell] == 5

--- a/tests/solvers/test_dijkstra_shortest_path.py
+++ b/tests/solvers/test_dijkstra_shortest_path.py
@@ -1,0 +1,14 @@
+"""Tests for the Dijkstra's Shortest Path solver."""
+from mazy.builders.dummy_builder import DummyBuilder
+from mazy.models.solver import SolverAlgorithm
+from mazy.solvers.dijkstra_shortest_path import DijkstraShortestPathSolver
+from mazy.utils import consume_generator
+
+
+def test_dijkstra_shortest_path_default_values() -> None:
+    """Ensure default values are consistent."""
+    builder = DummyBuilder(3, 5)
+    maze = consume_generator(builder.build_maze())
+    solver = DijkstraShortestPathSolver(maze)
+
+    assert solver.name == SolverAlgorithm.DIJKSTRA_SHORTEST_PATH.value

--- a/tests/viewers/test_ascii_viewer.py
+++ b/tests/viewers/test_ascii_viewer.py
@@ -15,7 +15,7 @@ def test_graphical_viewer_default_values() -> None:
 
 
 @pytest.mark.parametrize(("rows", "cols"), [(2, 2), (2, 3), (3, 2)])
-def test_ascii_viewer_maze_to_maze(
+def test_ascii_viewer_maze_to_str(
     rows: int,
     cols: int,
 ) -> None:
@@ -40,3 +40,31 @@ def test_ascii_viewer_maze_to_maze(
 
     for row in str_rows:
         assert len(row) == COL_SIZE * cols + 1
+
+
+@pytest.mark.parametrize(("rows", "cols"), [(2, 2), (2, 3), (3, 2)])
+@pytest.mark.parametrize(
+    ("cell_content", "printed_content"),
+    [
+        ("X", " X  "),
+        ("XY", " XY "),
+        ("XYZ", "XYZ "),
+        ("XYZW", "XYZW"),
+    ],
+)
+def test_ascii_viewer_maze_to_str_with_cell_content(
+    rows: int,
+    cols: int,
+    cell_content: str,
+    printed_content: str,
+) -> None:
+    """Ensure cell content is properly printed when exists."""
+    builder = BinaryTreeBuilder(rows, cols)
+    viewer = MazeTextViewer(builder)
+
+    for cell in builder.maze.traverse_by_cell():
+        cell.content = cell_content
+
+    maze_str = viewer.maze_to_str()
+
+    assert maze_str.count(printed_content) == rows * cols


### PR DESCRIPTION
Create basic structures to support Dijkstra's Shortest Path solver:
- New info to the Cell class (solution and content)
- Make cell object hashable
- Add new method to get neighbor cells with carved passage
- Implement the distance calculation to feed a new distances matrix object

Drive-by: reduce process maze calls: There is no need to reprocess the maze 
and calculate points and centers when the maze is already built.